### PR TITLE
Возможное исправление ложных срабатываний

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,8 @@ def contains_misspelling(text: str):
     for match in matches:
         if match.replacements:
             replacement = match.replacements[0]
-            if match.ruleIssueType == 'misspelling' and letter_counter(replacement) < letter_counter(text):
+            excess_letter_count = letter_counter(text) - letter_counter(replacement)
+            if match.ruleIssueType == 'misspelling' and excess_letter_count > 0 and len(text) == len(replacement) + excess_letter_count:
                 return True
     return False
 


### PR DESCRIPTION
Краткое объяснение: Кажется, что он часто криво срабатывает на слова в которых так-то нет опечатки, потому что замена предлагает далекое слово. Например, пользователь пишет слово `магматический` и программа находит лучшую замену = `маг`. В начальном тексте действительно больше `м` чем в ней, но там так же полно других букв. Поэтому надо проверять что в тексте именно лишние только буквы `м`. Понятно что мой вариант тоже не очень хорошо работает, потому что возможен случай когда слово совсем другое, а букв в нем именно на 1 больше, но кажется это немного улучшит ситуацию.

Кажется у меня есть мысли, как можно строить нужную регулярку, но хочу немного еще обдумать

**ЗЫ** Просмотри что я правильно написал все, а то питон давно не трогал и ПР писал прям в гитхабе)